### PR TITLE
Fix email sending with SMTP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # SMTP Configuration
-SMTP_HOST=smtp.gmail.com
-SMTP_PORT=587
-SMTP_USER=your-email@gmail.com
-SMTP_PASS=your-app-password
+SMTP_HOST=mailhog
+SMTP_PORT=1025
+SMTP_USER=
+SMTP_PASS=
 
 # Database Configuration (if needed in future)
 DB_HOST=localhost

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ docker-compose up -d
 
 4. Open your browser and navigate to `http://localhost:8000`
 
+### Local Email Testing
+
+To inspect outgoing emails during development, use the provided `docker-compose.override.yml`
+which starts a MailHog container. Emails sent by the application will be
+available at `http://localhost:8025`.
+
 ## Usage
 
 ### Web Interface
@@ -111,22 +117,23 @@ data/
 
 ## Environment Configuration
 
-Configure the following variables in your `.env` file:
+Configure the following variables in your `.env` file (example uses MailHog for local testing):
 
 ```env
 # SMTP Configuration
-SMTP_HOST=smtp.gmail.com
-SMTP_PORT=587
-SMTP_USER=your-email@gmail.com
-SMTP_PASS=your-app-password
+SMTP_HOST=mailhog
+SMTP_PORT=1025
+SMTP_USER=
+SMTP_PASS=
 
 # Application Configuration
 APP_URL=http://localhost:8000
 APP_ENV=development
 ```
 
-If the SMTP variables are left blank, the service will attempt to use the
-server's default mail configuration for sending notifications.
+SMTP must be configured for email delivery. When running `docker-compose` with the
+provided `docker-compose.override.yml`, MailHog will be available at `http://localhost:8025`
+and the default settings in `.env.example` will work out of the box.
 
 ## API Endpoints
 

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,9 @@
+version: "3.8"
+
+services:
+  mailhog:
+    image: mailhog/mailhog:v1.0.1
+    ports:
+      - "8025:8025"
+    networks:
+      - esignature-network

--- a/src/MailClient.php
+++ b/src/MailClient.php
@@ -1,0 +1,50 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
+/**
+ * Send an email using SMTP credentials defined in environment variables.
+ * Falls back to logging the message if sending fails.
+ */
+function sendEmail(string $to, string $subject, string $body): bool
+{
+    $mailer = new PHPMailer(true);
+
+    $smtpHost = getenv('SMTP_HOST');
+    $smtpPort = getenv('SMTP_PORT') ?: 587;
+    $smtpUser = getenv('SMTP_USER');
+    $smtpPass = getenv('SMTP_PASS');
+
+    try {
+        $mailer->isSMTP();
+        $mailer->Host       = $smtpHost;
+        $mailer->Port       = $smtpPort;
+        if ($smtpUser || $smtpPass) {
+            $mailer->SMTPAuth = true;
+            $mailer->Username = $smtpUser;
+            $mailer->Password = $smtpPass;
+        }
+        $mailer->SMTPSecure = $smtpPort == 465 ? PHPMailer::ENCRYPTION_SMTPS : PHPMailer::ENCRYPTION_STARTTLS;
+
+        $from = $smtpUser ?: 'no-reply@localhost';
+        $mailer->setFrom($from, 'E-Signature Service');
+        $mailer->addAddress($to);
+
+        $mailer->Subject = $subject;
+        $isHtml = $body !== strip_tags($body);
+        $mailer->isHTML($isHtml);
+        $mailer->Body    = $body;
+        if ($isHtml) {
+            $mailer->AltBody = strip_tags($body);
+        }
+
+        $mailer->send();
+        return true;
+    } catch (Exception $e) {
+        error_log('Email sending failed: ' . $e->getMessage());
+        error_log("[Email Fallback] To: $to Subject: $subject Body: $body");
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- replace old sendmail-based mailer with SMTP client
- add reusable `sendEmail` function
- document SMTP setup and MailHog usage
- provide `docker-compose.override.yml.example` for MailHog

## Testing
- `composer install` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856007fd7dc8327b87534d39a8af2bd